### PR TITLE
Release v0.6.7

### DIFF
--- a/docker-api/README.md
+++ b/docker-api/README.md
@@ -42,7 +42,7 @@ $ sudo systemctl status docker.service
 ```
 ## Download and Extract the package
 
-### For new peer setup
+### For new API setup
 
 **If you are upgrading from a previous version, please skip this section and go to next section below**
 
@@ -53,12 +53,17 @@ wget https://files.proximax.io/public-mainnet-api-package-latest.tar.gz.sha256
 shasum -c public-mainnet-api-package-latest.tar.gz.sha256
 # If ok, you have downloaded an authentic file, otherwise the file is corrupted.
 tar -xvf public-mainnet-api-package-latest.tar.gz
-# rename folder
-mv public-mainnet-api-package-v0.6.5 public-mainnet-api-package
 cd public-mainnet-api-package
 ```
 
 ## Upgrading
+
+---
+
+**v0.6.7 UPGRADE NOTES**
+>Please note that the following upgrade will replace your `config-node.properties`.  If you have previously assign a `friendlyName`, please see `Assign a friendly name in config-node.properties (OPTIONAL)`
+
+---
 
 The following instruction is assuming that existing node installation is located in `~/public-mainnet-api-package`.  If it is different, please change the path accordingly.
 
@@ -91,9 +96,8 @@ rsync -av --progress \
     --exclude 'data' \
     --exclude 'mongodata' \
     --exclude 'resources/config-user.properties' \
-    --exclude 'resources/config-node.properties' \
     --exclude 'resources/config-harvesting.properties' 
-    public-mainnet-api-package-v0.6.5/ ~/public-mainnet-api-package
+    public-mainnet-api-package/ ~/public-mainnet-api-package
 
 # resume docker
 cd ~/public-mainnet-api-package

--- a/docker-api/docker-compose.yml
+++ b/docker-api/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "3.6"
 services:
   db:
-    image: mongo:4.2-bionic
+    image: mongo:4.4-bionic
     command: bash -c "mongod --dbpath=/dbdata --bind_ip=db"
     volumes:
     - ./mongodata:/dbdata:rw
 
   init-db:
-    image: mongo:4.2-bionic
+    image: mongo:4.4-bionic
     command:  bash -c "/bin/bash /userconfig/mongors.sh"
     volumes:
     - ./mongodata:/dbdata:rw
@@ -17,7 +17,7 @@ services:
 
   catapult-api-node:
     # Downloads Catapult Server from specified Docker repo
-    image: proximax/proximax-sirius-chain:v0.6.5-buster
+    image: proximax/proximax-sirius-chain:v0.6.7-buster
     ports:
       - 7902:7902
       - 7900:7900
@@ -32,7 +32,7 @@ services:
     - db
 
   rest-gateway:
-    image: proximax/proximax-sirius-rest:v0.6.4
+    image: proximax/proximax-sirius-rest:v0.6.6
     ports:
     - "3000:3000"
     volumes:

--- a/docker-api/resources/config-node.properties
+++ b/docker-api/resources/config-node.properties
@@ -21,6 +21,7 @@ shortLivedCacheMaxSize = 10'000'000
 minFeeMultiplier = 0
 feeInterest = 1
 feeInterestDenominator = 1
+rejectEmptyBlocks = false
 transactionSelectionStrategy = oldest
 unconfirmedTransactionsCacheMaxResponseSize = 20MB
 unconfirmedTransactionsCacheMaxSize = 1'000'000

--- a/docker-api/resources/peers-api.json
+++ b/docker-api/resources/peers-api.json
@@ -45,39 +45,6 @@
             }
         },
         {
-            "publicKey": "0B92B3F6AFF833B6B702AFFB42C17585284E3BE3FCC6A1FA12D7C04CD0D44C39",
-            "endpoint": {
-                "host": "westerlund.xpxsirius.io",
-                "port": 7900
-            },
-            "metadata": {
-                "name": "teir1a-mainnet-chain-api1",
-                "roles": "Api"
-            }
-        },
-        {
-            "publicKey": "5FFA15A9416A06EB353C274B801148CF7E27C2FC0A05806D9DC9C26EE61B3D25",
-            "endpoint": {
-                "host": "canismajor.xpxsirius.io",
-                "port": 7900
-            },
-            "metadata": {
-                "name": "teir1a-mainnet-chain-api2",
-                "roles": "Api"
-            }
-        },
-        {
-            "publicKey": "5C563D977763F27DF9EB4885A5044B9785CFF5B98674AC84CA939B43938F5F2D",
-            "endpoint": {
-                "host": "coronaborealis.xpxsirius.io",
-                "port": 7900
-            },
-            "metadata": {
-                "name": "teir1a-mainnet-chain-api3",
-                "roles": "Api"
-            }
-        },
-        {
             "publicKey": "F0928275E7D8A06AF0E0438CE864BB80F1049FA4854D79E969EAD898E9F26836",
             "endpoint": {
                 "host": "delphinus.xpxsirius.io",
@@ -85,17 +52,6 @@
             },
             "metadata": {
                 "name": "tier1B-mainnet-chain-api1",
-                "roles": "Api"
-            }
-        },
-        {
-            "publicKey": "965EDD8F3C048FE92482FD1405E23C19574E2F97171F2FADA8EA8E3DEA520194",
-            "endpoint": {
-                "host": "eridanus.xpxsirius.io",
-                "port": 7900
-            },
-            "metadata": {
-                "name": "tier1B-mainnet-chain-api2",
                 "roles": "Api"
             }
         },

--- a/docker-api/restuserconfig/rest.json
+++ b/docker-api/restuserconfig/rest.json
@@ -1,7 +1,7 @@
 {
     "network": {
         "name": "public",
-        "description": "ProximaX Sirius Chain Network for MAINNET v0.6.2"
+        "description": "ProximaX Sirius Chain Network for MAINNET v0.6.7"
     },
 
     "port": 3000,

--- a/docker-method/README.md
+++ b/docker-method/README.md
@@ -53,12 +53,17 @@ wget https://files.proximax.io/public-mainnet-peer-package-latest.tar.gz.sha256
 shasum -c public-mainnet-peer-package-latest.tar.gz.sha256
 # If ok, you have downloaded an authentic file, otherwise the file is corrupted.
 tar -xvf public-mainnet-peer-package-latest.tar.gz
-# rename folder
-mv public-mainnet-peer-package-v0.6.5 public-mainnet-peer-package
 cd public-mainnet-peer-package
 ```
 
 ## Upgrading
+
+---
+
+**v0.6.7 UPGRADE NOTES**
+>Please note that the following upgrade will replace your `config-node.properties`.  If you have previously assign a `friendlyName`, please see `Assign a friendly name in config-node.properties (OPTIONAL)`
+
+---
 
 The following instruction is assuming that existing node installation is located in `~/public-mainnet-peer-package`.  If it is different, please change the path accordingly.
 
@@ -90,10 +95,8 @@ shasum -c public-mainnet-peer-package-latest.tar.gz.sha256
 rsync -av --progress \
     --exclude 'data' \
     --exclude 'resources/config-user.properties' \
-    --exclude 'resources/config-node.properties' \
     --exclude 'resources/config-harvesting.properties' 
-    public-mainnet-peer-package-v0.6.5/ ~/public-mainnet-peer-package
-
+    public-mainnet-peer-package/ ~/public-mainnet-peer-package
 # resume docker
 cd ~/public-mainnet-peer-package
 docker-compose up -d

--- a/docker-method/docker-compose.yml
+++ b/docker-method/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.6"
 services:
   mainnet-peer:
-    image: proximax/proximax-sirius-chain:v0.6.5-buster
+    image: proximax/proximax-sirius-chain:v0.6.7-buster
     ports:
       - 7902:7902
       - 7900:7900

--- a/docker-method/resources/config-node.properties
+++ b/docker-method/resources/config-node.properties
@@ -21,6 +21,7 @@ shortLivedCacheMaxSize = 10'000'000
 minFeeMultiplier = 0
 feeInterest = 1
 feeInterestDenominator = 1
+rejectEmptyBlocks = false
 transactionSelectionStrategy = oldest
 unconfirmedTransactionsCacheMaxResponseSize = 20MB
 unconfirmedTransactionsCacheMaxSize = 1'000'000

--- a/docker-method/resources/peers-api.json
+++ b/docker-method/resources/peers-api.json
@@ -45,39 +45,6 @@
             }
         },
         {
-            "publicKey": "0B92B3F6AFF833B6B702AFFB42C17585284E3BE3FCC6A1FA12D7C04CD0D44C39",
-            "endpoint": {
-                "host": "westerlund.xpxsirius.io",
-                "port": 7900
-            },
-            "metadata": {
-                "name": "teir1a-mainnet-chain-api1",
-                "roles": "Api"
-            }
-        },
-        {
-            "publicKey": "5FFA15A9416A06EB353C274B801148CF7E27C2FC0A05806D9DC9C26EE61B3D25",
-            "endpoint": {
-                "host": "canismajor.xpxsirius.io",
-                "port": 7900
-            },
-            "metadata": {
-                "name": "teir1a-mainnet-chain-api2",
-                "roles": "Api"
-            }
-        },
-        {
-            "publicKey": "5C563D977763F27DF9EB4885A5044B9785CFF5B98674AC84CA939B43938F5F2D",
-            "endpoint": {
-                "host": "coronaborealis.xpxsirius.io",
-                "port": 7900
-            },
-            "metadata": {
-                "name": "teir1a-mainnet-chain-api3",
-                "roles": "Api"
-            }
-        },
-        {
             "publicKey": "F0928275E7D8A06AF0E0438CE864BB80F1049FA4854D79E969EAD898E9F26836",
             "endpoint": {
                 "host": "delphinus.xpxsirius.io",
@@ -85,17 +52,6 @@
             },
             "metadata": {
                 "name": "tier1B-mainnet-chain-api1",
-                "roles": "Api"
-            }
-        },
-        {
-            "publicKey": "965EDD8F3C048FE92482FD1405E23C19574E2F97171F2FADA8EA8E3DEA520194",
-            "endpoint": {
-                "host": "eridanus.xpxsirius.io",
-                "port": 7900
-            },
-            "metadata": {
-                "name": "tier1B-mainnet-chain-api2",
                 "roles": "Api"
             }
         },


### PR DESCRIPTION
Release notes for:


Version | Description |
-- | --
v0.6.7 | Can't remove cosigner from multilevel multisig 
v0.6.6 | - Missed notifications for start verification, end drive by user, star file download <br>- Modify chain to generate blocks on demand <br> - Fix the crash in testnet with debit during end of drive 

